### PR TITLE
Add image-to-image generation for consistent character/product stills

### DIFF
--- a/src/app/api/images/generate/route.ts
+++ b/src/app/api/images/generate/route.ts
@@ -1,0 +1,115 @@
+import { GoogleGenAI } from "@google/genai";
+import { NextRequest, NextResponse } from "next/server";
+import type { StillImageResponse, StillImageGenerationRequest } from "@/types/still-image";
+
+const genAI = new GoogleGenAI({
+  apiKey: process.env.GOOGLE_AI_API_KEY!,
+});
+
+const GEMINI_MODEL = "gemini-2.5-flash-image-preview";
+const DEFAULT_MIME_TYPE = "image/png";
+
+// Helper function to create data URL from image data
+const createDataUrl = (imageData: string, mimeType: string): string => {
+  return `data:${mimeType};base64,${imageData}`;
+};
+
+// Helper function to process Gemini response and extract image data
+const processGeminiResponse = async (response: any) => {
+  if (response.candidates && response.candidates[0]) {
+    const candidate = response.candidates[0];
+
+    if (candidate.content && candidate.content.parts) {
+      for (const part of candidate.content.parts) {
+        // Check if this part contains image data
+        if (part.inlineData && part.inlineData.data) {
+          const imageData = part.inlineData.data;
+          const mimeType = part.inlineData.mimeType || DEFAULT_MIME_TYPE;
+
+          // Create data URL from image data
+          return createDataUrl(imageData, mimeType);
+        }
+      }
+    }
+  }
+
+  return null;
+};
+
+export async function POST(request: NextRequest) {
+  try {
+    const body: StillImageGenerationRequest = await request.json();
+
+    if (!body.prompt || !body.shotId) {
+      return NextResponse.json(
+        { error: "Prompt and shotId are required" },
+        { status: 400 }
+      );
+    }
+
+    if (!process.env.GOOGLE_AI_API_KEY) {
+      return NextResponse.json(
+        { error: "Google AI API key not configured" },
+        { status: 500 }
+      );
+    }
+
+    const enhancedPrompt = `Generate a professional, cinematic still image based on this description. The image should be in landscape orientation (16:9 aspect ratio) and suitable for a high-quality sizzle reel.
+
+${body.prompt}
+
+Make this visually stunning, professional, and cinematic in quality.${body.baseImage ? ' Use the provided reference image as a base for character/product consistency.' : ''}`;
+
+    const startTime = Date.now();
+
+    // Build the content array - include base image if provided
+    const contents: any[] = [{ text: enhancedPrompt }];
+
+    if (body.baseImage) {
+      // Extract mime type and base64 data from data URL
+      const [mimeTypePart, base64Data] = body.baseImage.split(',');
+      const mimeType = mimeTypePart.match(/data:([^;]+)/)?.[1] || DEFAULT_MIME_TYPE;
+
+      contents.push({
+        inlineData: {
+          mimeType,
+          data: base64Data
+        }
+      });
+    }
+
+    const response = await genAI.models.generateContent({
+      model: GEMINI_MODEL,
+      contents,
+    });
+
+    const processingTimeMs = Date.now() - startTime;
+
+    const imageUrl = await processGeminiResponse(response);
+
+    if (!imageUrl) {
+      console.error("No image generated in Gemini response");
+      return NextResponse.json(
+        { error: "Failed to generate image" },
+        { status: 500 }
+      );
+    }
+
+    const result: StillImageResponse = {
+      shotId: body.shotId,
+      imageUrl,
+      prompt: body.prompt,
+      processingTimeMs,
+      timestamp: new Date().toISOString(),
+    };
+
+    return NextResponse.json(result);
+
+  } catch (error) {
+    console.error("Still image generation error:", error);
+    return NextResponse.json(
+      { error: "Failed to generate still image" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/types/still-image.ts
+++ b/src/types/still-image.ts
@@ -1,0 +1,13 @@
+export interface StillImageGenerationRequest {
+  prompt: string;
+  shotId: string;
+  baseImage?: string; // Base64 encoded image for image-to-image generation
+}
+
+export interface StillImageResponse {
+  shotId: string;
+  imageUrl: string;
+  prompt: string;
+  processingTimeMs: number;
+  timestamp: string;
+}


### PR DESCRIPTION
## Summary
- Add base image upload functionality with file validation and preview
- Extend still image generation API to support reference images using Gemini 2.5 Flash Image Preview
- Update UI to pass base images for character/product consistency across shots
- Enhanced prompt engineering to leverage reference images for visual continuity

## Test plan
- [ ] Upload a base image and verify it shows preview
- [ ] Generate storyboard and verify stills use the base image for consistency
- [ ] Test without base image to ensure text-to-image still works
- [ ] Verify error handling for invalid file types

🤖 Generated with [Claude Code](https://claude.ai/code)