### PR TITLE
Display video clips for UI shots in storyboard sequence

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -340,6 +340,22 @@ export default function Home() {
                             ({(shot.endTime - shot.startTime).toFixed(1)}s duration)
                           </p>
                         </div>
+
+                        {videoFile && (
+                          <div className="border rounded-lg p-4 bg-background max-w-md">
+                            <video
+                              src={`${videoFile}#t=${shot.startTime},${shot.endTime}`}
+                              controls
+                              className="w-full h-auto rounded-md"
+                              preload="metadata"
+                            >
+                              Your browser does not support the video tag.
+                            </video>
+                            <p className="text-xs text-muted-foreground mt-2">
+                              Video clip: {shot.startTime.toFixed(1)}s - {shot.endTime.toFixed(1)}s
+                            </p>
+                          </div>
+                        )}
                       </div>
                     )}
 


### PR DESCRIPTION
## Summary
Adds video playback for UI shots, displaying the exact portion of the screen recording that will be used. Users can now preview how their cinematic and UI shots will flow together in the final sizzle reel.

## Features
- **Video player for UI shots**: Embedded directly in the storyboard display
- **Precise timestamp control**: Uses HTML5 `#t=start,end` fragment to cue video to exact timestamps
- **Visual preview**: Users see the actual clip that will be used in context
- **Responsive sizing**: Max width constraint (max-w-md) for better desktop display

## Implementation
- Video `src` includes fragment identifier: `video.mp4#t=5.0,12.5`
- Browser automatically seeks to start time and stops at end time
- Video controls allow users to play/pause and review the clip
- Maintains existing timestamp information display

## UX Benefits
- Clear understanding of shot sequencing
- Preview of cinematic-to-UI-to-cinematic flow
- Immediate visual feedback on AI's shot selection decisions
- Better context for manual UI clip editing (future feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)