### PR TITLE
Refine video generation with Veo 3 default and improved prompts

### DIFF
--- a/src/app/api/storyboard/generate/route.ts
+++ b/src/app/api/storyboard/generate/route.ts
@@ -107,13 +107,11 @@ VISUAL STORYTELLING:
 - Authentic settings: modest homes, community centers, truck stops, training facilities, highways
 - Technical cinematography details for AI generation: f-stop, focal length, lighting direction
 
-For CINEMATIC shots, make the video prompts extremely detailed and motion-focused, including:
-
-VIDEO PRODUCTION GUIDELINES:
-- Duration: 3-8 seconds per shot for sizzle reel pacing
+VIDEO PRODUCTION GUIDELINES (IMPORTANT - ALL VIDEOS ARE 8 SECONDS):
+- All generated videos will be exactly 8 seconds long
+- Structure video prompts with TIMESTAMPS to control pacing and action timing
+- Include specific timing for when key actions and emotional beats occur (e.g., "0:00-0:02 - character looks at phone, 0:02-0:05 - types message, 0:05-0:08 - smiles and looks up")
 - Camera movements: smooth dolly, crane, handheld, slider, gimbal movements
-- Pacing: slow, contemplative moments vs dynamic action sequences as appropriate
-- Timing: specific beats when key actions or emotions occur
 - Transitions: how the shot should begin and end to flow into next shot
 - Motion blur and depth changes throughout the sequence
 
@@ -137,7 +135,9 @@ STYLE GUARDRAILS (CRITICAL):
 - Neutral Rec.709 color grading - professional broadcast standard
 - NO glam filters, Instagram-style effects, or beauty enhancement
 - NO brand logos, product placement, or corporate branding visible
-- NO lip-sync mouth shapes or exaggerated facial expressions
+- NO dialogue, speech, talking, or lip-sync mouth movements
+- NO audio, sound effects, music, or any sound generation
+- Characters should NOT be speaking, singing, or making verbal sounds
 - NO extra fingers, body warping, or anatomical distortions
 - NO harsh, stylized color grading or heavy post-processing effects
 - NO text overlays, subtitles, or graphics in the shots

--- a/src/app/api/videos/generate/route.ts
+++ b/src/app/api/videos/generate/route.ts
@@ -51,8 +51,8 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Select model (default to veo-2)
-    const selectedModel = body.model || 'veo-2';
+    // Select model (default to veo-3)
+    const selectedModel = body.model || 'veo-3';
     const modelId = VEO_MODELS[selectedModel];
 
     if (!process.env.GOOGLE_AI_API_KEY) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,7 +25,7 @@ export default function Home() {
   const [generatingImages, setGeneratingImages] = useState<Record<string, boolean>>({});
   const [generatedVideos, setGeneratedVideos] = useState<Record<string, VideoGenerationResponse>>({});
   const [generatingVideos, setGeneratingVideos] = useState<Record<string, boolean>>({});
-  const [veoModel, setVeoModel] = useState<'veo-2' | 'veo-3'>('veo-2');
+  const [veoModel, setVeoModel] = useState<'veo-2' | 'veo-3'>('veo-3');
 
   const handleImageUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];

--- a/src/types/video-generation.ts
+++ b/src/types/video-generation.ts
@@ -6,11 +6,12 @@ export interface VideoGenerationRequest {
   shotId: string;
   imageUrl: string; // base64 data URL of the still image
   prompt: string; // motion/video prompt describing the desired animation
-  model?: 'veo-2' | 'veo-3'; // Which Veo model to use (default: veo-2)
+  model?: 'veo-2' | 'veo-3'; // Which Veo model to use (default: veo-3)
 }
 
 /**
  * Response from video generation API containing the generated video.
+ * Videos are always 8 seconds long (Veo default).
  */
 export interface VideoGenerationResponse {
   shotId: string;


### PR DESCRIPTION
## Summary
- Changes default video generation model from Veo 2 to Veo 3
- Updates storyboard generation to use timestamp-based pacing for 8-second videos
- Removes all speech, dialogue, and audio from generated videos
- Simplifies video duration handling (all videos are standardized to 8 seconds)

## Changes
- Default Veo model is now Veo 3 instead of Veo 2
- Storyboard prompts now structure video timing with timestamps (e.g., "0:00-0:02 - action, 0:02-0:05 - reaction")
- Added explicit guardrails against dialogue, speech, talking, lip-sync, and audio generation
- Removed complex duration logic - all videos are 8 seconds with timestamp-based pacing

## Test plan
- [x] Verify Veo 3 is selected by default in UI
- [x] Generate new storyboards and confirm timestamp structure in video prompts
- [x] Confirm no speech/audio guardrails appear in prompts
- [ ] Generate videos and verify they are 8 seconds long
- [ ] Verify videos don't include dialogue or speech

🤖 Generated with [Claude Code](https://claude.com/claude-code)