### PR TITLE
Add thumbnail previews to timeline shot blocks

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -688,6 +688,7 @@ export default function Home() {
                     setTimeout(() => setSeekTime(undefined), 100);
                   }}
                   generatedVideos={generatedVideos}
+                  generatedImages={generatedImages}
                 />
               </div>
             </CardContent>


### PR DESCRIPTION
## Summary
- Display visual thumbnails in timeline for better shot identification
- Cinematic shots: show generated still images
- UI shots: show video frame thumbnails  
- Fallback to gradient backgrounds if not generated yet
- Add dark overlay for text readability over thumbnails

## Implementation
- Pass `generatedImages` to Timeline component
- Use `<img>` for cinematic stills, `<video>` for UI clips
- Simple unified approach with clear fallback handling

## Test plan
- [x] Timeline shows still images for cinematic shots when generated
- [x] Timeline shows video thumbnails for UI shots when extracted
- [x] Timeline shows gradient backgrounds before generation
- [x] Text remains readable with dark overlay

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)