### PR TITLE
Refactor UI to focus-mode editing with expandable blocks

### DIFF
--- a/src/components/editors/BlockEditorPanel.tsx
+++ b/src/components/editors/BlockEditorPanel.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { ShotEditor } from "./ShotEditor";
+import { NarrationEditor } from "./NarrationEditor";
+import type { StoryboardResponse } from "@/types/storyboard";
+import type { StillImageResponse } from "@/types/still-image";
+import type { VideoGenerationResponse } from "@/types/video-generation";
+import type { NarrationGenerationResponse } from "@/types/narration";
+
+interface BlockEditorPanelProps {
+  selectedBlockId: string | null;
+  storyboard: StoryboardResponse;
+  generatedImages: Record<string, StillImageResponse>;
+  generatingImages: Record<string, boolean>;
+  generatedVideos: Record<string, VideoGenerationResponse>;
+  generatingVideos: Record<string, boolean>;
+  extractingClips: Record<string, boolean>;
+  generatedNarration: Record<string, NarrationGenerationResponse>;
+  generatingNarration: Record<string, boolean>;
+  videoFile: string | null;
+  baseImage: string | null;
+  veoModel: 'veo-2' | 'veo-3';
+  onGenerateStill: (shotId: string, prompt: string) => void;
+  onGenerateVideo: (shotId: string, prompt: string) => void;
+  onGenerateNarration: (narrationId: string, text: string) => void;
+  onVeoModelChange: (model: 'veo-2' | 'veo-3') => void;
+}
+
+export function BlockEditorPanel({
+  selectedBlockId,
+  storyboard,
+  generatedImages,
+  generatingImages,
+  generatedVideos,
+  generatingVideos,
+  extractingClips,
+  generatedNarration,
+  generatingNarration,
+  videoFile,
+  baseImage,
+  veoModel,
+  onGenerateStill,
+  onGenerateVideo,
+  onGenerateNarration,
+  onVeoModelChange,
+}: BlockEditorPanelProps) {
+  if (!selectedBlockId) {
+    return null;
+  }
+
+  // Check if it's a shot
+  const selectedShot = storyboard.shots.find(s => s.id === selectedBlockId);
+  if (selectedShot) {
+    return (
+      <div className="mt-6">
+        <ShotEditor
+          shot={selectedShot}
+          generatedImage={generatedImages[selectedShot.id]}
+          generatingImage={generatingImages[selectedShot.id]}
+          generatedVideo={generatedVideos[selectedShot.id]}
+          generatingVideo={generatingVideos[selectedShot.id]}
+          extractingClip={extractingClips[selectedShot.id]}
+          videoFile={videoFile}
+          baseImage={baseImage}
+          veoModel={veoModel}
+          onGenerateStill={onGenerateStill}
+          onGenerateVideo={onGenerateVideo}
+          onVeoModelChange={onVeoModelChange}
+        />
+      </div>
+    );
+  }
+
+  // Check if it's a narration segment
+  const selectedNarration = storyboard.narration?.find(n => n.id === selectedBlockId);
+  if (selectedNarration) {
+    return (
+      <div className="mt-6">
+        <NarrationEditor
+          segment={selectedNarration}
+          generatedNarration={generatedNarration[selectedNarration.id]}
+          generatingNarration={generatingNarration[selectedNarration.id]}
+          onGenerateNarration={onGenerateNarration}
+        />
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/components/editors/NarrationEditor.tsx
+++ b/src/components/editors/NarrationEditor.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import type { NarrationSegment } from "@/types/storyboard";
+import type { NarrationGenerationResponse } from "@/types/narration";
+
+interface NarrationEditorProps {
+  segment: NarrationSegment;
+  generatedNarration?: NarrationGenerationResponse;
+  generatingNarration?: boolean;
+  onGenerateNarration: (narrationId: string, text: string) => void;
+}
+
+export function NarrationEditor({
+  segment,
+  generatedNarration,
+  generatingNarration,
+  onGenerateNarration,
+}: NarrationEditorProps) {
+  return (
+    <div className="border-l-4 border-purple-500 pl-6 space-y-4">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <span className="font-mono">{segment.startTime.toFixed(1)}s - {segment.endTime.toFixed(1)}s</span>
+      </div>
+      <p className="text-sm italic">&quot;{segment.text}&quot;</p>
+      <div className="flex items-center gap-3">
+        <Button
+          onClick={() => onGenerateNarration(segment.id, segment.text)}
+          disabled={generatingNarration}
+          size="sm"
+          variant="outline"
+        >
+          {generatingNarration ? "Generating..." : "Generate Audio"}
+        </Button>
+        {generatedNarration && (
+          <audio
+            src={generatedNarration.audioUrl}
+            controls
+            className="h-8"
+          />
+        )}
+      </div>
+      {generatedNarration && (
+        <p className="text-xs text-muted-foreground">
+          Generated in {generatedNarration.processingTimeMs}ms
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/editors/ShotEditor.tsx
+++ b/src/components/editors/ShotEditor.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import type { StoryboardShot } from "@/types/storyboard";
+import type { StillImageResponse } from "@/types/still-image";
+import type { VideoGenerationResponse } from "@/types/video-generation";
+
+interface ShotEditorProps {
+  shot: StoryboardShot;
+  generatedImage?: StillImageResponse;
+  generatingImage?: boolean;
+  generatedVideo?: VideoGenerationResponse;
+  generatingVideo?: boolean;
+  extractingClip?: boolean;
+  videoFile?: string | null;
+  baseImage?: string | null;
+  veoModel: 'veo-2' | 'veo-3';
+  onGenerateStill: (shotId: string, prompt: string) => void;
+  onGenerateVideo: (shotId: string, prompt: string) => void;
+  onVeoModelChange: (model: 'veo-2' | 'veo-3') => void;
+}
+
+export function ShotEditor({
+  shot,
+  generatedImage,
+  generatingImage,
+  generatedVideo,
+  generatingVideo,
+  extractingClip,
+  videoFile,
+  baseImage,
+  veoModel,
+  onGenerateStill,
+  onGenerateVideo,
+  onVeoModelChange,
+}: ShotEditorProps) {
+  return (
+    <div className="border-l-4 border-primary pl-6 space-y-4">
+      <div className="flex items-center gap-2">
+        <span className="bg-primary text-primary-foreground px-2 py-1 rounded text-sm font-medium">
+          Shot {shot.order}
+        </span>
+        <span className={`px-2 py-1 rounded text-xs font-medium ${
+          shot.shotType === 'cinematic'
+            ? 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200'
+            : 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200'
+        }`}>
+          {shot.shotType === 'cinematic' ? '🎬 Cinematic' : '📱 UI'}
+        </span>
+        <h3 className="font-semibold">{shot.title}</h3>
+      </div>
+      <p className="text-sm text-muted-foreground">{shot.description}</p>
+
+      {shot.shotType === 'cinematic' ? (
+        <div className="space-y-3">
+          <div className="bg-muted p-3 rounded-md">
+            <p className="text-xs text-muted-foreground mb-1">Still Prompt:</p>
+            <p className="text-sm">{shot.stillPrompt}</p>
+          </div>
+
+          <div className="bg-muted p-3 rounded-md">
+            <p className="text-xs text-muted-foreground mb-1">Video Prompt:</p>
+            <p className="text-sm">{shot.videoPrompt}</p>
+          </div>
+
+          <div className="space-y-3">
+            <div className="space-y-2">
+              <Button
+                onClick={() => onGenerateStill(shot.id, shot.stillPrompt)}
+                disabled={generatingImage || !baseImage}
+                size="sm"
+              >
+                {generatingImage ? "Generating..." : "Generate Still"}
+              </Button>
+            </div>
+
+            {generatedImage && (
+              <div className="space-y-3">
+                <div className="border rounded-lg p-4 bg-background">
+                  <img
+                    src={generatedImage.imageUrl}
+                    alt={`Still for ${shot.title}`}
+                    className="w-full h-auto rounded-md"
+                  />
+                  <p className="text-xs text-muted-foreground mt-2">
+                    Generated in {generatedImage.processingTimeMs}ms
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <div className="flex items-center gap-3">
+                    <Button
+                      onClick={() => onGenerateVideo(shot.id, shot.videoPrompt)}
+                      disabled={generatingVideo}
+                      size="sm"
+                      variant="outline"
+                    >
+                      {generatingVideo ? "Generating Video..." : "Generate Video"}
+                    </Button>
+                    <select
+                      value={veoModel}
+                      onChange={(e) => onVeoModelChange(e.target.value as 'veo-2' | 'veo-3')}
+                      disabled={generatingVideo}
+                      className="h-9 px-3 rounded-md border border-input bg-background text-sm"
+                    >
+                      <option value="veo-2">Veo 2</option>
+                      <option value="veo-3">Veo 3</option>
+                    </select>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {generatingVideo
+                      ? "⏱️ This may take several minutes..."
+                      : "🎬 Convert still to video clip with motion"}
+                  </p>
+                </div>
+
+                {generatedVideo && (
+                  <div className="border rounded-lg p-4 bg-background">
+                    <video
+                      src={generatedVideo.videoUrl}
+                      controls
+                      className="w-full h-auto rounded-md"
+                      preload="metadata"
+                    >
+                      Your browser does not support the video tag.
+                    </video>
+                    <p className="text-xs text-muted-foreground mt-2">
+                      Video generated in {(generatedVideo.processingTimeMs / 1000).toFixed(1)}s
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <div className="bg-blue-50 dark:bg-blue-950 p-3 rounded-md border border-blue-200 dark:border-blue-800">
+            <p className="text-xs text-blue-700 dark:text-blue-300 mb-1">UI Screen Recording Clip:</p>
+            <p className="text-sm font-medium">{shot.uiDescription}</p>
+            <p className="text-xs text-muted-foreground mt-2">
+              Timestamp: {shot.startTime.toFixed(1)}s - {shot.endTime.toFixed(1)}s
+              ({(shot.endTime - shot.startTime).toFixed(1)}s duration)
+            </p>
+          </div>
+
+          {videoFile && (
+            <div className="border rounded-lg p-4 bg-background max-w-md">
+              {generatedVideo ? (
+                <>
+                  <video
+                    src={generatedVideo.videoUrl}
+                    controls
+                    className="w-full h-auto rounded-md"
+                  >
+                    Your browser does not support the video tag.
+                  </video>
+                  <p className="text-xs text-green-600 mt-2">
+                    ✓ Extracted clip ready
+                  </p>
+                </>
+              ) : extractingClip ? (
+                <div className="aspect-video flex items-center justify-center bg-muted rounded-md">
+                  <p className="text-sm text-muted-foreground">Extracting clip...</p>
+                </div>
+              ) : (
+                <>
+                  <video
+                    src={`${videoFile}#t=${shot.startTime},${shot.endTime}`}
+                    controls
+                    className="w-full h-auto rounded-md"
+                    preload="metadata"
+                  >
+                    Your browser does not support the video tag.
+                  </video>
+                  <p className="text-xs text-muted-foreground mt-2">
+                    Preview: {shot.startTime.toFixed(1)}s - {shot.endTime.toFixed(1)}s
+                  </p>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -10,9 +10,11 @@ interface TimelineProps {
   onSeek?: (time: number) => void;
   generatedVideos?: Record<string, any>;
   generatedImages?: Record<string, any>;
+  selectedBlockId?: string | null;
+  onSelectBlock?: (blockId: string) => void;
 }
 
-export function Timeline({ shots, narration, currentTime = 0, onSeek, generatedVideos = {}, generatedImages = {} }: TimelineProps) {
+export function Timeline({ shots, narration, currentTime = 0, onSeek, generatedVideos = {}, generatedImages = {}, selectedBlockId, onSelectBlock }: TimelineProps) {
   const { items: shotPositions, totalDuration } = useTimeline(shots);
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -46,6 +48,7 @@ export function Timeline({ shots, narration, currentTime = 0, onSeek, generatedV
             ? generatedImages[shot.id]?.imageUrl
             : generatedVideos[shot.id]?.videoUrl;
           const hasThumbnail = !!thumbnailUrl;
+          const isSelected = selectedBlockId === shot.id;
 
           const leftPercent = (startTime / totalDuration) * 100;
           const widthPercent = (duration / totalDuration) * 100;
@@ -53,10 +56,14 @@ export function Timeline({ shots, narration, currentTime = 0, onSeek, generatedV
           return (
             <div
               key={shot.id}
-              className="absolute top-0 bottom-0 border-r border-background overflow-hidden"
+              className={`absolute top-0 bottom-0 border-r border-background overflow-hidden cursor-pointer ${isSelected ? 'ring-2 ring-yellow-400 ring-inset z-20' : ''}`}
               style={{
                 left: `${leftPercent}%`,
                 width: `${widthPercent}%`,
+              }}
+              onClick={(e) => {
+                e.stopPropagation();
+                onSelectBlock?.(shot.id);
               }}
             >
               {/* Thumbnail background */}
@@ -120,16 +127,21 @@ export function Timeline({ shots, narration, currentTime = 0, onSeek, generatedV
           {narration.map((segment) => {
             const leftPercent = (segment.startTime / totalDuration) * 100;
             const widthPercent = ((segment.endTime - segment.startTime) / totalDuration) * 100;
+            const isSelected = selectedBlockId === segment.id;
 
             return (
               <div
                 key={segment.id}
-                className="absolute top-1 bottom-1 bg-purple-500/70 rounded border border-purple-600"
+                className={`absolute top-1 bottom-1 bg-purple-500/70 rounded border border-purple-600 cursor-pointer ${isSelected ? 'ring-2 ring-yellow-400 z-20' : ''}`}
                 style={{
                   left: `${leftPercent}%`,
                   width: `${widthPercent}%`,
                 }}
                 title={segment.text}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSelectBlock?.(segment.id);
+                }}
               >
                 <div className="px-1 text-xs text-white/90 truncate">
                   {segment.text}


### PR DESCRIPTION
## Summary
- Implement focus-mode editing workflow: show only Preview + Timeline, click blocks to edit
- Extract ShotEditor, NarrationEditor, and BlockEditorPanel components for better organization
- Remove old storyboard card that showed all shots/narration at once
- Add clickable timeline blocks with visual highlight (yellow ring) when selected
- Show editing panel only for selected block, below timeline

## Benefits
- Much cleaner, less overwhelming UI
- Better use of screen space
- Easier to focus on one shot/segment at a time
- Scalable for longer storyboards (50+ shots)
- More intuitive workflow: see → click → edit

## Implementation
- Created three new components: ShotEditor, NarrationEditor, BlockEditorPanel
- Timeline blocks now handle click events separately from seek
- Selected block shown with yellow ring highlight
- Only one editing panel visible at a time

## Test plan
- [x] Click timeline shot blocks to select and edit
- [x] Click narration blocks to select and edit
- [x] Visual highlight shows selected block
- [x] Editing panel displays correct content for selected block
- [x] UI remains clean with no clutter

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)