### PR TITLE
Fix video clip selection UI in timeline

### DIFF
--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -56,7 +56,7 @@ export function Timeline({ shots, narration, currentTime = 0, onSeek, generatedV
           return (
             <div
               key={shot.id}
-              className={`absolute top-0 bottom-0 border-r border-background overflow-hidden cursor-pointer ${isSelected ? 'ring-2 ring-yellow-400 ring-inset z-20' : ''}`}
+              className={`absolute top-0 bottom-0 border-r border-background overflow-hidden cursor-pointer ${isSelected ? 'ring-2 ring-green-500 z-20' : 'z-10'}`}
               style={{
                 left: `${leftPercent}%`,
                 width: `${widthPercent}%`,
@@ -111,7 +111,7 @@ export function Timeline({ shots, narration, currentTime = 0, onSeek, generatedV
 
         {/* Playhead */}
         <div
-          className="absolute top-0 bottom-0 w-0.5 bg-red-500 z-10 pointer-events-none"
+          className="absolute top-0 bottom-0 w-0.5 bg-red-500 z-30 pointer-events-none"
           style={{ left: `${Math.min((currentTime / totalDuration) * 100, 100)}%` }}
         >
           <div className="absolute -top-2 left-1/2 -translate-x-1/2 w-3 h-3 bg-red-500 rounded-full" />
@@ -132,7 +132,7 @@ export function Timeline({ shots, narration, currentTime = 0, onSeek, generatedV
             return (
               <div
                 key={segment.id}
-                className={`absolute top-1 bottom-1 bg-purple-500/70 rounded border border-purple-600 cursor-pointer ${isSelected ? 'ring-2 ring-yellow-400 z-20' : ''}`}
+                className={`absolute top-1 bottom-1 bg-purple-500/70 rounded border border-purple-600 cursor-pointer ${isSelected ? 'ring-2 ring-green-500 z-20' : 'z-10'}`}
                 style={{
                   left: `${leftPercent}%`,
                   width: `${widthPercent}%`,


### PR DESCRIPTION
## Problem
Fixes #63

When clicking video clips in the timeline:
1. Selection border wasn't visible (ring-inset hid it behind content)
2. Right edge of border was hidden by adjacent blocks  
3. Selected blocks appeared above playhead marker
4. Inconsistent z-index management

## Solution
- Removed `ring-inset` from selection styling (was hiding border behind video/image)
- Added explicit z-index layering:
  - Unselected blocks: `z-10` (base layer)
  - Selected blocks: `z-20` (rise above siblings to show full border)
  - Playhead: `z-30` (always on top)
- Changed selection color to green (`ring-green-500`) for better visibility
- Applied consistent styling to both shot blocks and narration segments

## Result
✅ Video clips now show visible green selection border when clicked
✅ Full border visible including right edge (selected blocks rise above neighbors)
✅ Playhead always visible on top of all blocks
✅ Consistent selection behavior across timeline elements

## Testing
Tested with multiple video clips and narration segments - selection is now clearly visible and playhead always stays on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)