### PR TITLE
Fix narration timeline blocks to reflect actual audio duration

### DIFF
--- a/src/app/api/narration/generate/route.ts
+++ b/src/app/api/narration/generate/route.ts
@@ -85,10 +85,18 @@ export async function POST(request: NextRequest) {
     const audioBase64 = Buffer.from(audioBuffer).toString('base64');
     const audioUrl = `data:audio/mpeg;base64,${audioBase64}`;
 
+    // Calculate audio duration from MP3 data
+    // We'll estimate based on bitrate and file size as a fallback
+    // Client will load the actual audio to get precise duration
+    const fileSizeBytes = audioBuffer.byteLength;
+    const estimatedBitrateKbps = 128; // ElevenLabs typically uses 128kbps
+    const estimatedDurationSeconds = (fileSizeBytes * 8) / (estimatedBitrateKbps * 1000);
+
     const result: NarrationGenerationResponse = {
       narrationId: body.narrationId,
       audioUrl,
       text: body.text,
+      durationSeconds: estimatedDurationSeconds,
       processingTimeMs,
       timestamp: new Date().toISOString(),
     };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -378,6 +378,19 @@ export default function Home() {
 
       const result: NarrationGenerationResponse = await response.json();
       setGeneratedNarration(prev => ({ ...prev, [narrationId]: result }));
+
+      // Load audio to get actual duration and update timeline
+      const audio = new Audio(result.audioUrl);
+      audio.addEventListener('loadedmetadata', () => {
+        const actualDuration = audio.duration;
+
+        // Update timeline with actual audio duration
+        setTimeline(prevTimeline => {
+          if (!prevTimeline) return prevTimeline;
+          return updateNarrationDuration(prevTimeline, narrationId, actualDuration);
+        });
+      });
+      audio.load();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to generate narration");
     } finally {

--- a/src/types/narration.ts
+++ b/src/types/narration.ts
@@ -15,6 +15,7 @@ export interface NarrationGenerationResponse {
   narrationId: string;
   audioUrl: string; // base64 data URL of the generated audio
   text: string;
+  durationSeconds: number; // actual duration of the generated audio file
   processingTimeMs: number;
   timestamp: string;
 }


### PR DESCRIPTION
## Summary
Updates narration timeline blocks to display actual audio file durations instead of AI-estimated durations from the storyboard.

## Changes
- **API Enhancement**: Added `durationSeconds` to `NarrationGenerationResponse` with estimated duration from MP3 file size
- **Client-side Duration Calculation**: Load audio on client to get precise duration from metadata
- **Timeline Update**: Use `updateNarrationDuration()` to update timeline with actual duration
- **State Management Fix**: Use functional `setTimeline()` update to handle concurrent narration generation

## Problem Solved
Previously, timeline blocks showed estimated durations (e.g., 5.5s) while actual audio was shorter (e.g., 4.73s), causing confusion about when narration actually plays and visual mismatch in the timeline.

## Test Plan
- [x] Generate storyboard with narration
- [x] Verify timeline blocks initially show estimated duration
- [x] Verify timeline blocks update to actual audio duration after loading
- [x] Verify works for both manual and auto-generated narration
- [x] Verify handles multiple concurrent narration generations correctly

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)