### PR TITLE
Add drag-and-drop repositioning for narration blocks

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,7 +15,7 @@ import type { Timeline as TimelineType } from "@/types/timeline";
 import { TimelineV2 } from "@/components/timeline/TimelineV2";
 import { PreviewPlayerV2 } from "@/components/timeline/PreviewPlayerV2";
 import { BlockEditorPanel } from "@/components/editors/BlockEditorPanel";
-import { storyboardToTimeline, updateNarrationDuration } from "@/lib/timelineConverter";
+import { storyboardToTimeline, updateNarrationDuration, updateClipPosition } from "@/lib/timelineConverter";
 
 export default function Home() {
   const [productDescription, setProductDescription] = useState("");
@@ -530,6 +530,12 @@ export default function Home() {
                     generatedNarration={generatedNarration}
                     selectedClipId={selectedBlockId}
                     onSelectClip={setSelectedBlockId}
+                    onClipPositionChange={(clipId, newStartTime) => {
+                      setTimeline(prevTimeline => {
+                        if (!prevTimeline) return prevTimeline;
+                        return updateClipPosition(prevTimeline, clipId, newStartTime);
+                      });
+                    }}
                   />
                 </div>
               )}


### PR DESCRIPTION
## Summary
Enables users to drag narration blocks horizontally in the timeline to adjust timing and prevent overlaps.

## Changes
- **TimelineV2 Component**:
  - Added drag state tracking and event handlers
  - Narration blocks now respond to mouse down/move/up events
  - Visual feedback: grab cursor → grabbing cursor + opacity change during drag
  - Real-time position updates as user drags
  - Constrained to timeline boundaries

- **Page Component**:
  - Wired up `onClipPositionChange` callback
  - Updates timeline state using `updateClipPosition` utility
  - Uses functional setState for consistency

## User Experience
- Hover shows grab cursor
- Click and drag to reposition narration
- Semi-transparent feedback while dragging
- Position updates immediately
- Visual overlap indicators already exist (darker overlapping areas)

## Technical Details
- Duration remains fixed (actual audio length)
- Position calculated from mouse delta and timeline width
- Clips bounded to [0, totalDuration]
- Uses existing `updateClipPosition` utility

## Scope
- ✅ Draggable positioning
- ❌ Resizable duration (not needed - fixed to audio length)
- ❌ Auto-fix overlaps (deferred)
- ❌ Waveforms (deferred)

## Test Plan
- [x] Generate storyboard with narration
- [x] Hover over narration block shows grab cursor
- [x] Click and drag narration block
- [x] Block follows mouse movement
- [x] Visual feedback (grabbing cursor + opacity)
- [x] Position updates in real-time
- [x] Overlapping narration shows visual indicator

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)