### PR TITLE
Fix old narration audio persisting on storyboard regeneration

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -210,6 +210,7 @@ export default function Home() {
 
       setGeneratedImages({}); // Clear previous images when new storyboard is generated
       setGeneratedVideos({}); // Clear previous videos when new storyboard is generated
+      setGeneratedNarration({}); // Clear previous narration when new storyboard is generated
 
       // Automatically extract UI clips if video is available
       if (videoFile) {

--- a/src/components/timeline/PreviewPlayerV2.tsx
+++ b/src/components/timeline/PreviewPlayerV2.tsx
@@ -48,6 +48,15 @@ export function PreviewPlayerV2({
     };
   }, []);
 
+  // Clear audio cache when generatedNarration changes (e.g., new storyboard)
+  useEffect(() => {
+    audioRefs.current.forEach((audio) => {
+      audio.pause();
+      audio.src = '';
+    });
+    audioRefs.current.clear();
+  }, [generatedNarration]);
+
   // Find current video clip
   const currentVideoClip = videoClips.find(
     clip => isVideoClip(clip) && currentTime >= clip.startTime && currentTime < (clip.startTime + clip.duration)


### PR DESCRIPTION
## Summary
Fixes bug where old narration audio continued playing after regenerating storyboard, despite timeline showing new narration text.

## Problem
When users regenerated a storyboard:
- Timeline blocks showed new narration text ✓
- Editor showed new generated audio ✓
- Preview played OLD narration audio ✗

## Root Cause
1. `generatedNarration` state was not cleared on new storyboard generation
2. PreviewPlayerV2 cached audio elements and never invalidated cache when narration changed

## Changes

**Page Component:**
- Clear `generatedNarration` state when generating new storyboard (line 213)
- Matches pattern for clearing images/videos

**PreviewPlayerV2 Component:**
- Added useEffect watching `generatedNarration` changes
- Clears audio element cache when narration state changes:
  - Pauses all cached audio
  - Clears sources
  - Removes from Map
- Forces fresh audio elements with new URLs

## Test Plan
- [x] Generate storyboard with narration
- [x] Wait for narration to auto-generate
- [x] Play preview - verify audio plays correctly
- [x] Generate new storyboard (different narration)
- [x] Wait for new narration to generate
- [x] Play preview - verify NEW audio plays (not old)
- [x] Timeline text matches audio content

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)