### PR TITLE
Show still images in preview when video not yet generated

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -499,17 +499,18 @@ export default function Home() {
             <CardHeader>
               <CardTitle>Preview</CardTitle>
               <CardDescription>
-                {Object.keys(generatedVideos).length > 0
+                {Object.keys(generatedVideos).length > 0 || Object.keys(generatedImages).length > 0
                   ? "Watch your sizzle reel come together. Click timeline blocks to edit individual shots or narration."
                   : "Click timeline blocks to edit individual shots or narration"}
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-6">
-              {timeline && Object.keys(generatedVideos).length > 0 && (
+              {timeline && (Object.keys(generatedVideos).length > 0 || Object.keys(generatedImages).length > 0) && (
                 <PreviewPlayerV2
                   timeline={timeline}
                   shots={shotsLookup}
                   generatedVideos={generatedVideos}
+                  generatedImages={generatedImages}
                   generatedNarration={generatedNarration}
                   onTimeUpdate={setPreviewTime}
                   seekTime={seekTime}

--- a/src/components/timeline/PreviewPlayerV2.tsx
+++ b/src/components/timeline/PreviewPlayerV2.tsx
@@ -11,6 +11,7 @@ interface PreviewPlayerV2Props {
   timeline: TimelineType;
   shots: Record<string, StoryboardShot>;
   generatedVideos: Record<string, { videoUrl: string }>;
+  generatedImages: Record<string, { imageUrl: string }>;
   generatedNarration: Record<string, { audioUrl: string }>;
   onTimeUpdate?: (time: number) => void;
   seekTime?: number;
@@ -20,6 +21,7 @@ export function PreviewPlayerV2({
   timeline,
   shots,
   generatedVideos,
+  generatedImages,
   generatedNarration,
   onTimeUpdate,
   seekTime,
@@ -64,6 +66,9 @@ export function PreviewPlayerV2({
 
   const currentShot = currentVideoClip ? shots[currentVideoClip.shotId] : null;
   const videoUrl = currentShot ? generatedVideos[currentShot.id]?.videoUrl : null;
+  const stillUrl = currentShot?.shotType === 'cinematic'
+    ? generatedImages[currentShot.id]?.imageUrl
+    : null;
 
   // Helper: Get or create audio element
   const getOrCreateAudio = useCallback((clip: AudioClip): HTMLAudioElement | null => {
@@ -233,11 +238,17 @@ export function PreviewPlayerV2({
             className="max-h-full max-w-full object-contain"
             muted
           />
+        ) : stillUrl ? (
+          <img
+            src={stillUrl}
+            alt={`Shot ${currentShot?.order}: ${currentShot?.title}`}
+            className="max-h-full max-w-full object-contain"
+          />
         ) : (
           <div className="text-center space-y-2">
             <p className="text-muted-foreground font-medium">
               {currentShot?.shotType === 'cinematic'
-                ? 'Generate video for this shot to preview'
+                ? 'Generate still or video for this shot to preview'
                 : 'No video clip at this time'}
             </p>
           </div>

--- a/src/components/timeline/TimelineV2.tsx
+++ b/src/components/timeline/TimelineV2.tsx
@@ -112,6 +112,8 @@ export function TimelineV2({
                 e.stopPropagation();
                 // Pass the shot ID (not clip ID) for editor compatibility
                 onSelectClip?.(shot.id);
+                // Seek to shot's start time to show it in preview
+                onSeek?.(clip.startTime);
               }}
             >
               {/* Thumbnail background */}


### PR DESCRIPTION
## Summary
Enables preview player to display still images when videos aren't yet generated, and updates preview when clicking on shot blocks.

## Problem
- Cinematic shots with still images but no video showed black screen
- Clicking shot blocks didn't update the preview to show that shot
- Users couldn't see visual content while waiting for video generation

## Solution

**PreviewPlayerV2:**
- Added `generatedImages` prop
- 3-level fallback: video → still image → placeholder
- Updated placeholder message to mention both still and video

**TimelineV2:**
- Clicking shot blocks now seeks preview to that shot's start time
- Calls both `onSelectClip` (for editor) and `onSeek` (for preview)

**Page:**
- Passed `generatedImages` to PreviewPlayerV2
- Show preview when videos OR images exist (not just videos)

## User Experience
1. Stills auto-generate after storyboard creation
2. Preview appears immediately showing still images
3. Click any shot block → preview seeks and displays that shot
4. Videos generate later → seamlessly replace stills
5. No black screens during video generation

## Test Plan
- [x] Generate storyboard with cinematic shots
- [x] Stills auto-generate
- [x] Preview player appears showing still images
- [x] Click different shot blocks - preview updates to show each shot
- [x] Generate video - video replaces still in preview
- [x] Scrub timeline - preview shows appropriate content

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)