### PR TITLE
Fix prompt persistence when switching between shots

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -273,6 +273,16 @@ export default function Home() {
       return;
     }
 
+    // Update storyboard with edited prompt to persist it
+    if (storyboard) {
+      setStoryboard({
+        ...storyboard,
+        shots: storyboard.shots.map(shot =>
+          shot.id === shotId ? { ...shot, stillPrompt: prompt } : shot
+        ),
+      });
+    }
+
     setGeneratingImages(prev => ({ ...prev, [shotId]: true }));
 
     const previousShots: string[] = [];
@@ -317,6 +327,16 @@ export default function Home() {
     if (!imageData?.imageUrl) {
       setError("Please generate a still image first before creating a video");
       return;
+    }
+
+    // Update storyboard with edited prompt to persist it
+    if (storyboard) {
+      setStoryboard({
+        ...storyboard,
+        shots: storyboard.shots.map(shot =>
+          shot.id === shotId ? { ...shot, videoPrompt: prompt } : shot
+        ),
+      });
     }
 
     setGeneratingVideos(prev => ({ ...prev, [shotId]: true }));

--- a/src/components/editors/EditablePromptButton.tsx
+++ b/src/components/editors/EditablePromptButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, ReactNode } from "react";
+import { useState, useEffect, ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 
 interface EditablePromptButtonProps {
@@ -28,6 +28,14 @@ export function EditablePromptButton({
   const [promptEditing, setPromptEditing] = useState(false);
   const [editedPrompt, setEditedPrompt] = useState(initialPrompt);
   const [promptModified, setPromptModified] = useState(false);
+
+  // Sync local state when initialPrompt changes (e.g., switching shots)
+  useEffect(() => {
+    setEditedPrompt(initialPrompt);
+    setPromptModified(false);
+    setPromptExpanded(false);
+    setPromptEditing(false);
+  }, [initialPrompt]);
 
   return (
     <>


### PR DESCRIPTION
## Bug Description
When editing still/video prompts and regenerating, the edited prompt would revert to the original text when switching to another shot and returning.

## Root Causes

**Issue 1: Local state not syncing**
`EditablePromptButton` used `useState(initialPrompt)` which only initializes once on mount. When switching shots, the new `initialPrompt` prop was ignored.

**Issue 2: Edited prompts not persisted**
`handleGenerateStill` and `handleGenerateVideo` used the edited prompt for generation but never updated the storyboard state, so the original prompt was still stored.

## Solution

**Part 1: Sync local state on prop changes**
Added `useEffect` in `EditablePromptButton` to sync local state whenever `initialPrompt` changes:
- Updates `editedPrompt` to new `initialPrompt`
- Resets `promptModified` flag
- Collapses expanded/editing UI

**Part 2: Persist edited prompts to storyboard**
Updated `handleGenerateStill` and `handleGenerateVideo` to save edited prompts back to storyboard state before generation:
```typescript
setStoryboard({
  ...storyboard,
  shots: storyboard.shots.map(shot =>
    shot.id === shotId ? { ...shot, stillPrompt: prompt } : shot
  ),
});
```

## Testing
1. Edit a shot's still prompt
2. Click "Regenerate Still"
3. Switch to another shot
4. Return to the original shot
5. Prompt should show the edited text (not reverted)

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)