### PR TITLE
Add automatic video compression for large uploads

### DIFF
--- a/src/app/api/video/compress/route.ts
+++ b/src/app/api/video/compress/route.ts
@@ -1,0 +1,141 @@
+/**
+ * Video Compression API Route
+ *
+ * Compresses videos that exceed size limits for Gemini video analysis.
+ * Maintains aspect ratio and frame rate while reducing file size.
+ *
+ * POST /api/video/compress
+ *
+ * Request body:
+ * - videoData: base64 data URL of video
+ * - targetSizeMB: target file size in MB (default: 9)
+ *
+ * Response:
+ * - compressedVideo: base64 data URL of compressed video
+ * - originalSize: original file size in bytes
+ * - compressedSize: compressed file size in bytes
+ * - compressionRatio: ratio of compression
+ * - processingTimeMs: time taken to compress
+ *
+ * Note: Uses /tmp directory which has 512MB limit on Vercel (see issue #102)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { exec } from "child_process";
+import { promisify } from "util";
+import { writeFile, unlink, mkdir, stat } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import { tmpdir } from "os";
+
+const execAsync = promisify(exec);
+
+interface VideoCompressRequest {
+  videoData: string; // base64 data URL
+  targetSizeMB?: number; // target size in MB (default: 9)
+}
+
+interface VideoCompressResponse {
+  compressedVideo: string; // base64 data URL
+  originalSize: number; // bytes
+  compressedSize: number; // bytes
+  compressionRatio: number; // e.g., 0.5 means 50% of original
+  processingTimeMs: number;
+  timestamp: string;
+}
+
+export async function POST(request: NextRequest) {
+  const tempDir = path.join(tmpdir(), 'sizzle-reel-compress');
+  const tempFiles: string[] = [];
+
+  try {
+    const body: VideoCompressRequest = await request.json();
+
+    if (!body.videoData) {
+      return NextResponse.json(
+        { error: "videoData is required" },
+        { status: 400 }
+      );
+    }
+
+    const startTime = Date.now();
+    const targetSizeMB = body.targetSizeMB || 9; // Default to 9MB to stay under 10MB limit
+
+    // Create temp directory if it doesn't exist
+    if (!existsSync(tempDir)) {
+      await mkdir(tempDir, { recursive: true });
+    }
+
+    // Extract base64 data and write to temp file
+    const base64Data = body.videoData.split(',')[1] || body.videoData;
+    const videoBuffer = Buffer.from(base64Data, 'base64');
+    const originalSize = videoBuffer.length;
+
+    const inputPath = path.join(tempDir, `input-${Date.now()}.mp4`);
+    await writeFile(inputPath, videoBuffer);
+    tempFiles.push(inputPath);
+
+    // Output path
+    const outputPath = path.join(tempDir, `compressed-${Date.now()}.mp4`);
+    tempFiles.push(outputPath);
+
+    // Compress video with FFmpeg
+    // Strategy: reduce resolution and increase CRF for smaller file size
+    // - Scale down to max 1280px width (maintains aspect ratio)
+    // - CRF 28 (higher = more compression, lower quality)
+    // - Fast preset for faster encoding
+    // - faststart for web streaming
+    const ffmpegCommand = `ffmpeg -i "${inputPath}" -vf "scale='min(1280,iw)':-2" -c:v libx264 -crf 28 -preset fast -movflags +faststart -an -y "${outputPath}"`;
+
+    await execAsync(ffmpegCommand, { timeout: 120000 }); // 2 minute timeout
+
+    // Read compressed video
+    const { readFile } = await import('fs/promises');
+    const compressedBuffer = await readFile(outputPath);
+    const compressedSize = compressedBuffer.length;
+
+    // Check if compression achieved target
+    const compressedSizeMB = compressedSize / (1024 * 1024);
+    if (compressedSizeMB > targetSizeMB) {
+      console.warn(`Compressed video (${compressedSizeMB.toFixed(2)}MB) exceeds target (${targetSizeMB}MB)`);
+    }
+
+    const compressedBase64 = compressedBuffer.toString('base64');
+    const compressedVideo = `data:video/mp4;base64,${compressedBase64}`;
+
+    const compressionRatio = compressedSize / originalSize;
+    const processingTimeMs = Date.now() - startTime;
+
+    const result: VideoCompressResponse = {
+      compressedVideo,
+      originalSize,
+      compressedSize,
+      compressionRatio,
+      processingTimeMs,
+      timestamp: new Date().toISOString(),
+    };
+
+    return NextResponse.json(result);
+
+  } catch (error) {
+    console.error("Video compression error:", error);
+    return NextResponse.json(
+      {
+        error: "Failed to compress video",
+        details: error instanceof Error ? error.message : String(error)
+      },
+      { status: 500 }
+    );
+  } finally {
+    // Cleanup temp files
+    for (const filePath of tempFiles) {
+      try {
+        if (existsSync(filePath)) {
+          await unlink(filePath);
+        }
+      } catch (cleanupError) {
+        console.error("Cleanup error:", cleanupError);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Implements two-tier video system for handling large uploads
- Automatic compression for videos over 10MB
- Maintains original quality for final export
- Seamless user experience with progress indicators

## Problem Solved
Previously, videos over 10MB were rejected. Users had to manually compress or trim videos before uploading, creating friction and potentially losing important footage.

## Solution

**Compression API Endpoint**
- `POST /api/video/compress`
- Uses FFmpeg with optimized settings for web video
- Scale to max 1280px width (maintains aspect ratio)
- CRF 28 for good quality/size balance
- Fast preset for faster processing
- Strips audio (not needed for analysis)
- Target: compress to under 9MB

**Two-Tier Video System**
```typescript
videoFile: string | null           // Original (for clip extraction)
compressedVideoFile: string | null // Compressed (for analysis)
```

**Upload Flow**
1. User uploads video (any size)
2. If over 10MB:
   - Store original for later use
   - Compress video automatically
   - Show "Compressing video..." status
   - Store compressed version
3. If under 10MB:
   - Use original for both analysis and extraction

**Analysis Flow**
- Send compressed video to Gemini for analysis
- Timestamps are identical (same duration, same time codes)
- Analysis results reference original video timeline

**Extraction Flow**
- Use **original video** for UI clip extraction
- Apply timestamps from analysis
- Final sizzle reel contains high-quality UI footage

## UI Changes
- Removed "Max 10MB" file size restriction message
- Added "Compressing video..." progress indicator (blue)
- Updated description to mention automatic compression
- Kept "Recommended under 60 seconds" guidance

## Technical Details
FFmpeg compression command:
```bash
ffmpeg -i input.mp4 \
  -vf "scale='min(1280,iw)':-2" \
  -c:v libx264 -crf 28 -preset fast \
  -movflags +faststart -an \
  compressed.mp4
```

## Testing
- Tested with 15MB video file
- Compression successful (15MB → ~6MB)
- Quality acceptable for analysis
- Original video preserved for extraction
- Timestamps align correctly

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)